### PR TITLE
Improve layout and reduce whitespace in home page sections

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,18 +24,17 @@
   class="section-full mt-12 flex flex-col items-center bg-white pb-12 pt-12 dark:bg-neutral-200 lg:mt-40 lg:pb-40 lg:pt-20"
 >
   <h2
-    class="mb-4 bg-gradient-to-r from-primary-100 via-accent-magenta to-accent-cyan bg-clip-text text-3xl font-bold text-transparent dark:to-primary-400 lg:mb-8 lg:text-4xl"
+    class="mb-8 bg-gradient-to-r from-primary-100 via-accent-magenta to-accent-cyan bg-clip-text text-3xl font-bold text-transparent dark:to-primary-400 lg:mb-12 lg:text-4xl"
   >
     Features
   </h2>
-  <div class="mx-auto flex w-[90%] max-w-5xl flex-col items-center gap-4 lg:gap-32">
-    <OverviewCard
-      heading="Find Good first issues"
-      description="in the Eddiehub Github Organization or in the entire Eddiehub organization"
-    >
+  <div
+    class="mx-auto grid w-[90%] max-w-5xl gap-y-15 gap-x-8 grid-cols-1 md:grid-cols-3 items-center"
+  >
+    <!-- First Card -->
+    <div class="flex flex-col items-center text-center">
       <svg
         class="h-[50px] w-[50px] lg:h-[100px] lg:w-[100px]"
-        slot="image"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         role="img"
@@ -51,34 +50,33 @@
         <path
           fill="url(#0)"
           d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Zm9.5 2a2 2 0 1 1-.001-3.999A2 2 0 0 1 12 14Z"
-        /></svg
-      >
-    </OverviewCard>
-    <OverviewCard
-      textFieldAlignment="right"
-      heading="Filter by labels"
-      description="Filter the returned data by labels, to specify and narrow down the search even more"
-    >
+        />
+      </svg>
+      <h3 class="mt-4 text-xl font-bold">Find Good first issues</h3>
+      <p class="mt-2 text-sm">
+        Find issues in the Eddiehub Github Organization or in the entire Eddiehub organization
+      </p>
+    </div>
+
+    <!-- Second Card -->
+    <div class="flex flex-col items-center text-center">
       <i
-        slot="image"
         class="fa-solid fa-filter bg-gradient-to-tr from-primary-100 via-accent-magenta to-primary-200 bg-clip-text text-5xl text-transparent lg:text-8xl"
-        role="img"
-        aria-label="filter image"
-        title="filter image"
-      />
-    </OverviewCard>
-    <OverviewCard
-      heading="Search"
-      description="Search the Github Issues for specific words or phrases"
-    >
+      ></i>
+      <h3 class="mt-4 text-xl font-bold">Filter by labels</h3>
+      <p class="mt-2 text-sm">
+        Filter the returned data by labels, to specify and narrow down the search even more
+      </p>
+    </div>
+
+    <!-- Third Card -->
+    <div class="flex flex-col items-center text-center">
       <i
-        slot="image"
         class="fa-solid fa-magnifying-glass bg-gradient-to-r from-primary-100 to-accent-magenta bg-clip-text text-5xl text-transparent lg:text-8xl"
-        role="img"
-        aria-label="magnifying glass"
-        title="magnifying glass"
-      />
-    </OverviewCard>
+      ></i>
+      <h3 class="mt-4 text-xl font-bold">Search</h3>
+      <p class="mt-2 text-sm">Search the Github Issues for specific words or phrases</p>
+    </div>
   </div>
 </section>
 <section class="mb-12 mt-12 flex flex-col items-center space-y-8 lg:mb-20 lg:mt-20">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,12 +16,13 @@
 
 <Seo {title} {metadescription} />
 
-<div class="mt-16 flex flex-col items-center gap-16 px-4 lg:mt-32 lg:gap-32">
+<div class="mt-16 flex flex-col items-center gap-16 px-2 lg:mt-12 lg:gap-12">
   <Hero />
   <HeroImage />
 </div>
+
 <section
-  class="section-full mt-12 flex flex-col items-center bg-white pb-12 pt-12 dark:bg-neutral-200 lg:mt-40 lg:pb-40 lg:pt-20"
+  class="section-full mt-12 flex flex-col items-center bg-white pb-12 pt-12 dark:bg-neutral-200 lg:mt-20 lg:pb-20 lg:pt-20"
 >
   <h2
     class="mb-8 bg-gradient-to-r from-primary-100 via-accent-magenta to-accent-cyan bg-clip-text text-3xl font-bold text-transparent dark:to-primary-400 lg:mb-12 lg:text-4xl"


### PR DESCRIPTION
### Description:
- Updated the layout of the "Features" section to display icons above titles with two rows and three columns.
- Reduced unnecessary whitespace between elements in the features section by adjusting grid and flexbox settings.
- Increased vertical padding below the "Features" heading for better spacing.
- Reduced horizontal spacing in the main content and section areas for a more compact layout.

### Changes:
- Adjusted grid system to align icons above titles and create a two-row, three-column layout.
- Applied gap adjustments to reduce horizontal and vertical space between content blocks.
- Tweaked margin and padding values for the "Features" heading and other components to improve spacing consistency.

### Screenshots:
<img width="910" alt="Screenshot 2024-10-02 at 12 06 55 AM" src="https://github.com/user-attachments/assets/b8f896e9-9c52-485c-9785-998dfb22b05f">
<img width="1130" alt="Screenshot 2024-10-02 at 12 05 37 AM" src="https://github.com/user-attachments/assets/3f807b80-4ccf-4ae5-b466-a74ccef509cf">


### Issue reference:
Resolves Issue [#322](https://github.com/EddieHubCommunity/good-first-issue-finder/issues/322)
